### PR TITLE
readme: remove empty pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use League\CommonMark\Environment;
 use League\CommonMark\Ext\Autolink\InlineMentionParser;
 
 $environment = Environment::createCommonMarkEnvironment();
-$environment->addInlineParser(new InlineMentionParser('https://www.example.com/users/%s/profile', '/^[A-Za-z0-9_]+(?!\w)/'));
+$environment->addInlineParser(new InlineMentionParser('https://www.example.com/users/%s/profile'));
 
 // TODO: Instantiate your converter and convert some Markdown
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use League\CommonMark\Environment;
 use League\CommonMark\Ext\Autolink\InlineMentionParser;
 
 $environment = Environment::createCommonMarkEnvironment();
-$environment->addInlineParser(new InlineMentionParser('https://www.example.com/users/%s/profile', ''));
+$environment->addInlineParser(new InlineMentionParser('https://www.example.com/users/%s/profile', '/^[A-Za-z0-9_]+(?!\w)/'));
 
 // TODO: Instantiate your converter and convert some Markdown
 ```


### PR DESCRIPTION
empty pattern is not valid, so remove it.

the alternative would be to use default pattern, but I don't like repeating.

the error with empty pattern is:

```
( ! ) Warning: preg_match(): Empty regular expression in  vendor/league/commonmark/src/Cursor.php on line 394
```